### PR TITLE
sources and javadoc plugins moved to 'full' profile to speed up re-packaging while in development

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,17 +85,6 @@
 				<!-- to be used with modules that do have tests -->
 				<!-- <plugin> <groupId>org.apache.maven.plugins</groupId> <artifactId>maven-surefire-plugin</artifactId> 
 					<version>2.4</version> </plugin> -->
-				<!-- associare questi due plugin ai soli profili che si usa per compilare 
-					la versione da distribuire... TODO -->
-
-				<!-- Attach sources <plugin> <groupId>org.apache.maven.plugins</groupId> 
-					<artifactId>maven-source-plugin</artifactId> <version>2.1.2</version> <executions> 
-					<execution> <id>attach-sources</id> <goals> <goal>jar</goal> </goals> </execution> 
-					</executions> </plugin> -->
-				<!-- Attach javadoc <plugin> <groupId>org.apache.maven.plugins</groupId> 
-					<artifactId>maven-javadoc-plugin</artifactId> <version>2.8</version> <executions> 
-					<execution> <id>attach-javadocs</id> <goals> <goal>jar</goal> </goals> </execution> 
-					</executions> </plugin> -->
 			</plugins>
 
 		</pluginManagement>
@@ -159,7 +148,7 @@
 			<dependency>
 				<groupId>org.primefaces</groupId>
 				<artifactId>primefaces</artifactId>
-				<version>3.4.2</version>
+				<version>3.3</version>
 			</dependency>
 			<!--<dependency> <groupId>org.primefaces.themes</groupId> <artifactId>aristo</artifactId> 
 				<version>1.0.3</version> </dependency> -->
@@ -279,6 +268,42 @@
 	</dependencies>
 
 	<profiles>
+		<profile>
+			<id>full</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-source-plugin</artifactId>
+						<version>2.1.2</version>
+						<executions>
+							<execution>
+								<id>attach-sources</id>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<version>2.8</version>
+						<executions>
+							<execution>
+								<id>attach-javadocs</id>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 
 	<distributionManagement>


### PR DESCRIPTION
repackaging while in development
